### PR TITLE
Changed list_schemas() method to only return JSON files in table_schemas directory.

### DIFF
--- a/time_management/ddl.py
+++ b/time_management/ddl.py
@@ -42,8 +42,5 @@ class DataDefinitionLanguage:
 
     @staticmethod
     def list_schemas():
-        return [
-            f
-            for f in os.listdir(DataDefinitionLanguage.__schemas_path)
-            if os.path.isfile(os.path.join(DataDefinitionLanguage.__schemas_path, f))
-        ]
+        return [pos_json for pos_json in os.listdir(DataDefinitionLanguage.__schemas_path) if pos_json.endswith('.json')]
+        

--- a/time_management/test/ddll_test.py
+++ b/time_management/test/ddll_test.py
@@ -1,6 +1,7 @@
 import ddl
 import sqlitedb
 import unittest
+import os
 
 
 class DDLTest(unittest.TestCase):
@@ -23,3 +24,14 @@ class DDLTest(unittest.TestCase):
         self.assertTrue("notes.json" in schemas)
         self.assertTrue("tasks.json" in schemas)
         self.assertTrue("user_config.json" in schemas)
+
+    def test_nonJSON_invisible_in_schemas(self):
+        filepath = os.path.join(os.path.dirname(__file__), '../table_schemas/test_temp.txt')
+        with open(filepath, "a") as temp_file:
+            temp_file.write("Hello, World!")
+        schemas = ddl.DataDefinitionLanguage.list_schemas()
+        self.assertTrue("notes.json" in schemas)
+        self.assertTrue("tasks.json" in schemas)
+        self.assertTrue("user_config.json" in schemas)
+        self.assertFalse("test_temp.txt" in schemas)
+        os.remove(filepath)


### PR DESCRIPTION
Added tests in the DDL test suite as well (create a temp_test.txt file, make a call to ddl.DataDefinitionLanguage.list_schemas(), verify file is not read, and delete temp file). 

Let me know if any commenting is needed (didn't add any since it seemed like most of the code in the repo was comment free)

For issue #64 